### PR TITLE
allow to use symbols for getting injected dependencies

### DIFF
--- a/src/common/interfaces/nest-application-context.interface.ts
+++ b/src/common/interfaces/nest-application-context.interface.ts
@@ -12,5 +12,5 @@ export interface INestApplicationContext {
    * Makes possible to retrieve the instance of the component or controller available inside the processed module.
    * @returns T
    */
-  get<T>(metatypeOrToken: Metatype<T> | string): T;
+  get<T>(metatypeOrToken: Metatype<T> | string | Symbol): T;
 }


### PR DESCRIPTION
It needed when you want to get dependency via app with app.select(Module).get(SomeSymbol)
similar to #278